### PR TITLE
Add an example with crossorigin font preloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@ document.head.appendChild(res);
 &lt;link rel="preload" href="/assets/font.woff" as="font"&gt;
 &lt;link rel="preload" href="/style/other.css" as="style"&gt;
 &lt;link rel="preload" href="//example.com/resource"&gt;
+&lt;link rel="preload" href="https://fonts.example.com/font.woff" as="font" crossorigin&gt;
 </pre>
       <p>Above markup initiates three resource fetches: a font resource, a
       stylesheet, and an unknown resource type from another origin. Each fetch
@@ -334,6 +335,7 @@ document.head.appendChild(res);
   Link: &lt;https://example.com/font.woff&gt;; rel=preload; as=font
   Link: &lt;https://example.com/app/script.js&gt;; rel=preload; as=script
   Link: &lt;https://example.com/logo-hires.jpg&gt;; rel=preload; as=image
+  Link: &lt;https://fonts.example.com/font.woff&gt;; rel=preload; as=font; crossorigin
 </pre>
       <pre class="example highlight js">
   &lt;link rel="preload" href="//example.com/widget.html" as="iframe"&gt;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Preload</title>
   <meta charset='utf-8'>
-  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class=
+  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class=
   'remove'>
   </script>
   <script class='remove'>
@@ -281,11 +281,15 @@ document.head.appendChild(res);
 &lt;link rel="preload" href="//example.com/resource"&gt;
 &lt;link rel="preload" href="https://fonts.example.com/font.woff" as="font" crossorigin&gt;
 </pre>
-      <p>Above markup initiates three resource fetches: a font resource, a
-      stylesheet, and an unknown resource type from another origin. Each fetch
+      <p>Above markup initiates four resource fetches: a font resource, a
+      stylesheet, an unknown resource type from another origin, and a font resource from another origin. Each fetch
       is initialized with appropriate request headers and priority - the
       unknown type is equivalent to a fetch initiated `XMLHttpRequest` request.
       Further, these requests do not block the parser or the load event.</p>
+      <p class="note">Preload links for CORS enabled resources,
+      such as fonts or images with a `crossorigin` attribute,
+      must also include a `crossorigin` attribute,
+      in order for the resource to be properly used.</p>
     </section>
     <section>
       <h2>Early fetch and application defined execution</h2>


### PR DESCRIPTION
Closes https://github.com/w3c/preload/issues/32 by clarifying that a `crossorigin` attribute is required for fonts and other CORS-enabled fetches.
