### PR TITLE
Add support for `nopush` target attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,19 @@ document.head.appendChild(res);
       <p>The server MAY initiate server push for <a>preload link</a> resources
       defined by the application for which it is [authoritative][]. Initiating
       server push eliminates the request roundtrip between client and server
-      for the declared <a>preload link</a> resource.</p>
+      for the declared <a>preload link</a> resource. Optionally, if the use of
+      server push is not desired for a resource declared via the `Link` header
+      field ([[!RFC5988]]), the developer MAY provide an opt-out signal to the
+      server via the `nopush` target attribute ([[!RFC5988]] section 5.4). For
+      example:</p>
+      <pre class="example">
+  Link: &lt;/font.woff&gt;; rel=preload; as=font; nopush
+  Link: &lt;/app/script.js&gt;; rel=preload; as=script
+</pre>
+      <p class="note">The above example indicates to an HTTP/2 push capable
+      server that `/font.woff` should not be pushed (e.g. the origin may have
+      additional information indicating that it may already be in cache), while
+      `/app/script.js` should be considered as a candidate for server push.</p>
       <p>Initiating server push for a <a>preload link</a> is an optional
       optimization. For example, the server might omit initiating push if it
       believes that the response is available in the client's cache: the client

--- a/index.html
+++ b/index.html
@@ -285,13 +285,14 @@ document.head.appendChild(res);
       server via the `nopush` target attribute ([[!RFC5988]] section 5.4). For
       example:</p>
       <pre class="example">
-  Link: &lt;/font.woff&gt;; rel=preload; as=font; nopush
+  Link: &lt;/app/style.css&gt;; rel=preload; as=style; nopush
   Link: &lt;/app/script.js&gt;; rel=preload; as=script
 </pre>
       <p class="note">The above example indicates to an HTTP/2 push capable
-      server that `/font.woff` should not be pushed (e.g. the origin may have
-      additional information indicating that it may already be in cache), while
-      `/app/script.js` should be considered as a candidate for server push.</p>
+      server that `/app/style.css` should not be pushed (e.g. the origin may
+      have additional information indicating that it may already be in cache),
+      while `/app/script.js` should be considered as a candidate for server
+      push.</p>
       <p>Initiating server push for a <a>preload link</a> is an optional
       optimization. For example, the server might omit initiating push if it
       believes that the response is available in the client's cache: the client


### PR DESCRIPTION
As currently defined, all preload links delivered via the Link header
are candidates for HTTP/2 server push (subject to client and server
preferences). However, sometimes developer may want to exclude a
particular resource from being a candidate for server push - e.g. it
believes the user already has it in cache, or it needs the client to
initiate the request to see the correct cookies, etc.

To enable this, developer can provide the optional `nopush` target
attribute. When this attribute is present, HTTP/2+push capable servers
should not initiate server for this resource. For example:

```
Link: </font.woff>; rel=preload; as=font; nopush
```

Previous discussion in https://github.com/w3c/preload/pull/54. 

/cc @mnot @kazuho @icing @yoavweiss 
