### PR TITLE
Changed request type to request destination

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,14 +188,14 @@ document.head.appendChild(res);
         <li>[Resolve] the [URL] (<i>absolute url</i>) given by the `href`
         attribute, relative to the element.</li>
         <li>If the previous step fails, then abort these steps.</li>
-        <li>Validate the <i>request type</i> given by the `as` attribute. If
+        <li>Validate the <i>request destination</i> given by the `as` attribute. If
         the attribute is omitted, or the provided value is not a [valid request
-        type], then initialize it to the empty string. [[!FETCH]]</li>
+        destination], then initialize it to the empty string. [[!FETCH]]</li>
         <li>Do a potentially CORS-enabled fetch of the resulting <i>absolute
         URL</i>, with the <i>mode</i> being the current state of the element's
         [crossorigin] content attribute, the <i>origin</i> being the [origin]
-        of the [link] element's [node document], <i>type</i> set to <i>request
-        type</i>, and the <i>default origin behavior</i> set to
+        of the [link] element's [node document], <i>destination</i> set to <i>request
+        destination</i>, and the <i>default origin behavior</i> set to
         <i>taint</i>.</li>
       </ol>
       <p>The <a>preload link</a> element MUST NOT [delay the load event] of the
@@ -257,7 +257,7 @@ document.head.appendChild(res);
         <dd>
           The value of this element's <a href="#widl-HTMLLinkElement-as">as</a>
           attribute. The value of this attribute MUST be a [valid request
-          type]. If the provided value is omitted, or invalid, the value should
+          destination]. If the provided value is omitted, or invalid, the value should
           be initialized to the empty string.
         </dd>
       </dl>
@@ -515,7 +515,7 @@ document.head.appendChild(res);
 [evaluates to false]: http://drafts.csswg.org/mediaqueries/#mq-list
 [resolve]: https://html.spec.whatwg.org/multipage/infrastructure.html#resolve-a-url
 [url]: https://html.spec.whatwg.org/multipage/infrastructure.html#url
-[valid request type]: https://fetch.spec.whatwg.org/#concept-request-type
+[valid request destination]: https://fetch.spec.whatwg.org/#concept-request-destination
 [crossorigin]: https://html.spec.whatwg.org/multipage/semantics.html#attr-link-crossorigin
 [origin]: https://html.spec.whatwg.org/multipage/browsers.html#origin-2
 [node document]: https://dom.spec.whatwg.org/#concept-node-document


### PR DESCRIPTION
As https://github.com/whatwg/fetch/pull/211 landed, this PR does s/request type/request destination/

Closes https://github.com/w3c/preload/issues/55 and https://github.com/w3c/preload/issues/37
