### PR TITLE
Restore obtain logic for `type`

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,11 @@ document.head.appendChild(res);
         obtained due to the `as` attribute specifying an unsupported <a>request
         destination</a> is set, removed, or changed.
         </li>
+        <li>When the `type` attribute of the [link] element of a <a>preload
+        link</a> that is already [in a Document] but was previously not
+        obtained due to the `type` attribute specifying an unsupported
+        <a>request destination</a> is set, removed, or changed.
+        </li>
         <li>When the `media` attribute of the [link] element of a <a>preload
         link</a> that is already [in a Document] contains a [valid media query
         list] that [matches the environment] of the user. Otherwise, if the


### PR DESCRIPTION
See https://github.com/w3c/preload/commit/3af93e1f8129e6858f58d9fe68ff30506eef8f45. 

/cc @yoavweiss 
