### PR TITLE
Add [CEReactions] annotation to as

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@ document.head.appendChild(res);
     <section>
       <h2>Link element interface extensions</h2>
       <dl title='partial interface HTMLLinkElement' class="idl">
-        <dt>attribute DOMString as</dt>
+        <dt>[CEReactions] attribute DOMString as</dt>
         <dd>
           The value of this element's <a href="#widl-HTMLLinkElement-as">as</a>
           attribute. The value of this attribute MUST be a [valid request


### PR DESCRIPTION
Since the as attribute can change the DOM in ways that may impact custom elements, it needs to be annotated with the [CEReactions] attribute. This is part of the larger effort at w3c/webcomponents#186. [CEReactions] is defined in https://html.spec.whatwg.org/multipage/scripting.html#cereactions.
