### PR TITLE
Remove text indicating invalid as values are converted to an empty value

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@ document.head.appendChild(res);
         <dd>
           The value of this element's <a href="#widl-HTMLLinkElement-as">as</a>
           attribute. The value of this attribute MUST be a [valid request
-          destination]. If the provided value is omitted, or invalid, the value
+          destination]. If the provided value is omitted, the value
           should be initialized to the empty string.
         </dd>
       </dl>


### PR DESCRIPTION
This was missed when committing #58 

We shouldn't say that invalid values are converted to empty ones as this contradicts the processing model changes from #58 and what we agreed on in #36 
