### PR TITLE
Better define what `as` does as well as define the Link header equivalent

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,13 @@
       company: "Google",
       companyURL: "https://google.com/",
       w3cid: "56102"
+    }, {
+      name: "Yoav Weiss",
+      url: "https://blog.yoav.ws/",
+      mailto: "yoav@yoav.ws",
+      company: "Akamai",
+      companyURL: "https://akamai.com/",
+      w3cid: "58673"
     }, ],
     wg: "Web Performance Working Group",
     wgURI: "http://www.w3.org/webperf/",
@@ -274,8 +281,8 @@ partial interface HTMLLinkElement {
       application of the correct [[!CSP3]] policy, and setting of the
       appropriate `Accept` request header.</p>
       <p>When the resource is declared via the `Link` header field
-      ([[!RFC5988]]), the resource's `as` attribute would be defined via the
-      `as` link-extension target attribute. ([[!RFC5988]] section 5.4)</p>
+      ([[!RFC5988]]), the resource's `as` attribute would be defined via
+      the `as` link-extension target attribute. ([[!RFC5988]] section 5.4)</p>
 
       <div class="example">
         <p>Example directives to preload a resource that will be consumed

--- a/index.html
+++ b/index.html
@@ -266,12 +266,17 @@ partial interface HTMLLinkElement {
 };
 </pre>
       <p>The <dfn for="HTMLLinkElement">as</dfn> attribute's value MUST be a
-      [valid request destination]. If the provided value is omitted, the value
+      valid [request destination]. If the provided value is omitted, the value
       is initialized to the empty string.</p>
-      <p>Request defaults set by the user agent via `as` attribute MUST match
-      the default settings set by the user agent when processing a resource
-      with the same context. This behavior is necessary to guarantee correct
-      prioritization and request matching.</p>
+      <p>The user agent must set the [request destination] provided by `as`, as
+      well as the corresponding [request type] and [request initiator]. This is
+      necessary to guarantee correct prioritization, request matching,
+      application of the correct [[!CSP3]] policy, and setting of the
+      appropriate `Accept` request header.</p>
+      <p>When the resource is declared via the `Link` header field
+      ([[!RFC5988]]), the resource's `as` attribute would be defined via the
+      `as` link-extension target attribute. ([[!RFC5988]] section 5.4)</p>
+
       <div class="example">
         <p>Example directives to preload a resource that will be consumed
         by...</p>
@@ -589,7 +594,9 @@ partial interface HTMLLinkElement {
 [evaluates to false]: http://drafts.csswg.org/mediaqueries/#mq-list
 [resolve]: https://html.spec.whatwg.org/multipage/infrastructure.html#resolve-a-url
 [url]: https://html.spec.whatwg.org/multipage/infrastructure.html#url
-[valid request destination]: https://fetch.spec.whatwg.org/#concept-request-destination
+[request destination]: https://fetch.spec.whatwg.org/#concept-request-destination
+[request type]: https://fetch.spec.whatwg.org/#concept-request-type
+[request initiator]: https://fetch.spec.whatwg.org/#concept-request-initiator
 [crossorigin]: https://html.spec.whatwg.org/multipage/semantics.html#attr-link-crossorigin
 [origin]: https://html.spec.whatwg.org/multipage/browsers.html#origin-2
 [node document]: https://dom.spec.whatwg.org/#concept-node-document

--- a/index.html
+++ b/index.html
@@ -275,15 +275,14 @@ partial interface HTMLLinkElement {
       <p>The <dfn for="HTMLLinkElement">as</dfn> attribute's value MUST be a
       valid [request destination]. If the provided value is omitted, the value
       is initialized to the empty string.</p>
-      <p>The user agent must set the [request destination] provided by `as`, as
+      <p>The user agent MUST set the [request destination] provided by `as`, as
       well as the corresponding [request type] and [request initiator]. This is
       necessary to guarantee correct prioritization, request matching,
       application of the correct [[!CSP3]] policy, and setting of the
       appropriate `Accept` request header.</p>
       <p>When the resource is declared via the `Link` header field
-      ([[!RFC5988]]), the resource's `as` attribute would be defined via
-      the `as` link-extension target attribute. ([[!RFC5988]] section 5.4)</p>
-
+      ([[!RFC5988]]), the resource's `as` attribute is defined via the `as`
+      link-extension target attribute. ([[!RFC5988]] section 5.4)</p>
       <div class="example">
         <p>Example directives to preload a resource that will be consumed
         by...</p>


### PR DESCRIPTION
Discussion on [the addition of a "referrerpolicy" attribute to `<link>`](https://codereview.chromium.org/2424943002/) resulted in the conclusion that added attributes to `Link:` need to be explicitly specified in the relevant specs, which is also relevant for `as`.

This PR does that, clarifies the language around what `as` does (in terms of Fetch), and adds myself as an editor.

Note that it somewhat breaks the output HTML, in what seems to be a [Respec issue](https://github.com/w3c/respec/issues/958).