### PR TITLE
Split out the `as=media` example into video, audio and track

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,8 +296,17 @@ partial interface HTMLLinkElement {
           </thead>
           <tbody>
             <tr>
-              <td><code>&lt;audio&gt;, &lt;video&gt;</code></td>
-              <td><code>&lt;link rel=preload as=media href=...&gt;</code></td>
+              <td><code>&lt;audio&gt;</code></td>
+              <td><code>&lt;link rel=preload as=audio href=...&gt;</code></td>
+            </tr>
+            <tr>
+            <tr>
+              <td><code>&lt;video&gt;</code></td>
+              <td><code>&lt;link rel=preload as=video href=...&gt;</code></td>
+            </tr>
+            <tr>
+              <td><code>&lt;track&gt;</code></td>
+              <td><code>&lt;link rel=preload as=track href=...&gt;</code></td>
             </tr>
             <tr>
               <td><code>&lt;script&gt;</code>, Worker's


### PR DESCRIPTION
Closes #93


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/preload/remove_media_from_examples.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/preload/39acc00...yoavweiss:108561b.html)