### PR TITLE
Add fetch `as` value to examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@ document.head.appendChild(res);
             </tr>
             <tr>
               <td>XHR, fetch</td>
-              <td><code>&lt;link rel=preload href=...&gt;</code></td>
+              <td><code>&lt;link rel=preload as=fetch href=...&gt;</code></td>
             </tr>
             <tr>
               <td>Worker, SharedWorker</td>

--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@ document.head.appendChild(res);
       "Early fetch of critical resources">
 &lt;link rel="preload" href="/assets/font.woff2" as="font" type="font/woff2"&gt;
 &lt;link rel="preload" href="/style/other.css" as="style"&gt;
-&lt;link rel="preload" href="//example.com/resource"&gt;
+&lt;link rel="preload" href="//example.com/resource" as="fetch"&gt;
 &lt;link rel="preload" href="https://fonts.example.com/font.woff2" as="font" crossorigin type="font/woff2"&gt;
 </pre>
       <p>Above markup initiates four resource fetches: a font resource, a


### PR DESCRIPTION
The example in 2.2 wasn't synced after #80 was closed. This PR should do the trick.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/preload/fetch_in_example.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/preload/01d2c0c...yoavweiss:9bb2d0b.html)