### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     subjectPrefix: "[preload]",
     format: "markdown",
     // noLegacyStyle: true,
+    testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/preload",
     otherLinks: [{
       key: 'Repository',
       data: [{


### PR DESCRIPTION
Many other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://w3c.github.io/ServiceWorker/
https://webaudio.github.io/web-audio-api/
https://xhr.spec.whatwg.org/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/foolip/preload/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/preload/6948b97...foolip:d6dfff0.html)