### PR TITLE
Add a note regarding media attribute mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,10 @@ document.head.appendChild(res);
       <div class="note">
         Link HTTP response header should be processed for all types of <a>request destination</a>.
       </div>
+      <div class="note">
+        When the `media` attribute's value does not <a>match the environment</a>,
+        the resource will not be preloaded.
+      </div>
       <p>The user agent MUST NOT automatically execute or apply the resource
       against the current page context.</p>
       <p class="note">For example, if a JavaScript resource is fetched via a


### PR DESCRIPTION
At https://bugs.chromium.org/p/chromium/issues/detail?id=792038, the conclusion was that a note regarding the behavior in case `media` doesn't match the environment is required.
This adds such a note.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/preload/pull/117.html" title="Last updated on Jan 9, 2018, 12:08 PM GMT (fe1234b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/preload/117/609ecfa...yoavweiss:fe1234b.html" title="Last updated on Jan 9, 2018, 12:08 PM GMT (fe1234b)">Diff</a>