### PR TITLE
editorial: enable caniuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,8 @@
     // noLegacyStyle: true,
     testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/preload",
     github: "https://github.com/w3c/preload/",
-    wgPatentURI: "https://www.w3.org/2004/01/pp-impl/45211/status"
+    wgPatentURI: "https://www.w3.org/2004/01/pp-impl/45211/status",
+    caniuse: "link-rel-preload",
   };
   </script>
 </head>


### PR DESCRIPTION
Adds a browser support table based on data from caniuse.com (Read about this recently added ReSpec feature [here](https://github.com/w3c/respec/wiki/caniuse))

Note: This feature is only available in "live" Editor's Drafts. You can preview it by adding [`?caniuse=link-rel-preload`](https://w3c.github.io/preload/?caniuse=link-rel-preload) as a URL parameter.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/preload/pull/124.html" title="Last updated on Jun 14, 2018, 8:55 AM GMT (e1d73e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/preload/124/09af38e...sidvishnoi:e1d73e3.html" title="Last updated on Jun 14, 2018, 8:55 AM GMT (e1d73e3)">Diff</a>