### PR TITLE
Preload is not always high priority

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ document.head.appendChild(res);
     <p class="note" title="relationship to prefetch">Both <a>prefetch</a> and `preload` declare a resource and its fetch
     properties, but differ in how and when the resource is fetched by the user
     agent: <a>prefetch</a> is an optional and often low-priority fetch for a resource that
-    might be used by a subsequent navigation; `preload` is a mandatory and
+    might be used by a subsequent navigation; `preload` is a mandatory
     fetch for a resource that is necessary for the current navigation. Developers
     should use each one accordingly to minimize resource contention and optimize load
     performance.</p>

--- a/index.html
+++ b/index.html
@@ -158,11 +158,11 @@ document.head.appendChild(res);
     check</a> to verify that it is supported.</p>
     <p class="note" title="relationship to prefetch">Both <a>prefetch</a> and `preload` declare a resource and its fetch
     properties, but differ in how and when the resource is fetched by the user
-    agent: <a>prefetch</a> is an optional and low-priority fetch for a resource that
+    agent: <a>prefetch</a> is an optional and often low-priority fetch for a resource that
     might be used by a subsequent navigation; `preload` is a mandatory and
-    high-priority fetch for a resource that is necessary for the current
-    navigation. Developers should use each one accordingly to minimize resource
-    contention and optimize load performance.</p>
+    fetch for a resource that is necessary for the current navigation. Developers
+    should use each one accordingly to minimize resource contention and optimize load
+    performance.</p>
     <section>
       <h2>Processing</h2>
       <p>The <dfn>appropriate times</dfn> to <a>obtain the resource</a> are:</p>


### PR DESCRIPTION
Seems that https://github.com/w3c/preload/pull/53 added the "relationship to prefetch" note, which mentions prioritization that is not always true/backed by the spec. A lot of people are confused that preload is always fetched with high priority, but this isn't always this case, and since priorities are not standardized, I'm not sure if we can really include that.

I've included text indicating that prefetch is "often" low-priority, but if we want to remove any trace of prioritization from there too I'm happy to do that as well.

Fixes https://github.com/w3c/preload/issues/125. /cc @yoavweiss


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domfarolino/preload/pull/128.html" title="Last updated on Aug 21, 2018, 11:51 PM GMT (fa59296)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/preload/128/8e17302...domfarolino:fa59296.html" title="Last updated on Aug 21, 2018, 11:51 PM GMT (fa59296)">Diff</a>