### PR TITLE
chore: fix ReSpec errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Preload</title>
   <meta charset='utf-8'>
-  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class=
+  <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=
   'remove'></script>
   <script class='remove'>
   var respecConfig = {
@@ -30,7 +30,6 @@
     license: 'w3c-software-doc',
     wgPublicList: "public-web-perf",
     subjectPrefix: "[preload]",
-    format: "markdown",
     // noLegacyStyle: true,
     testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/preload",
     github: "https://github.com/w3c/preload/",


### PR DESCRIPTION
There have been some changes in markdown processing, which are incompatible with this document. Also, markdown is not used in the document, so removing it.

As an add-on, changed ReSpec script to lite jQuery-less version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/preload/pull/141.html" title="Last updated on Dec 30, 2019, 12:45 PM UTC (2537b7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/preload/141/8c8304c...sidvishnoi:2537b7a.html" title="Last updated on Dec 30, 2019, 12:45 PM UTC (2537b7a)">Diff</a>